### PR TITLE
ブランチ名に/が含まれ流場合に対応

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ exports.slack_handler = function(event, context, callback) {
         return null
 
     const command_text = params['text']
-    let match = command_text.match(/([-_.+0-9a-zA-Z]*) *to +(production|staging|app|android|ios|codepush|web|apk)/)
+    let match = command_text.match(/([-_.+0-9a-zA-Z/]*) *to +(production|staging|app|android|ios|codepush|web|apk)/)
     if (match) {
         let branch = match[1] || 'master'
         let target = match[2]


### PR DESCRIPTION
ブランチ名に`/`が含まれる場合にも正しく処理できるように修正。